### PR TITLE
Fix migration for django 1.9

### DIFF
--- a/metro/migrations/0001_initial.py
+++ b/metro/migrations/0001_initial.py
@@ -1,10 +1,12 @@
 # -*- coding: utf-8 -*-
+from __future__ import unicode_literals
 
-
-from django.db import models, migrations
+from django.db import migrations, models
+import django.db.models.deletion
 
 
 class Migration(migrations.Migration):
+    initial = True
 
     dependencies = [
     ]
@@ -13,37 +15,34 @@ class Migration(migrations.Migration):
         migrations.CreateModel(
             name='Metro',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('title', models.CharField(max_length=255, verbose_name='\u041d\u0430\u0437\u0432\u0430\u043d\u0438\u0435')),
-                ('order', models.PositiveIntegerField(default=0, verbose_name='\u041f\u043e\u0440\u044f\u0434\u043e\u043a')),
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=255, verbose_name='Название')),
+                ('order', models.PositiveIntegerField(default=0, verbose_name='Порядок')),
             ],
             options={
+                'verbose_name': 'Станция метро',
                 'ordering': ['order'],
-                'verbose_name': '\u0421\u0442\u0430\u043d\u0446\u0438\u044f \u043c\u0435\u0442\u0440\u043e',
-                'verbose_name_plural': '\u0421\u0442\u0430\u043d\u0446\u0438\u0438 \u043c\u0435\u0442\u0440\u043e',
+                'verbose_name_plural': 'Станции метро',
             },
-            bases=(models.Model,),
         ),
         migrations.CreateModel(
             name='MetroLine',
             fields=[
-                ('id', models.AutoField(verbose_name='ID', serialize=False, auto_created=True, primary_key=True)),
-                ('title', models.CharField(max_length=255, verbose_name='\u041d\u0430\u0437\u0432\u0430\u043d\u0438\u0435')),
-                ('color', models.CharField(max_length=255, null=True, verbose_name='\u0426\u0432\u0435\u0442', blank=True)),
-                ('number', models.IntegerField(null=True, verbose_name='\u041d\u043e\u043c\u0435\u0440 \u043b\u0438\u043d\u0438\u0438', blank=True)),
-                ('icon', models.ImageField(upload_to=b'metro/', null=True, verbose_name='\u0418\u043a\u043e\u043d\u043a\u0430', blank=True)),
+                ('id', models.AutoField(auto_created=True, primary_key=True, serialize=False, verbose_name='ID')),
+                ('title', models.CharField(max_length=255, verbose_name='Название')),
+                ('color', models.CharField(blank=True, max_length=255, null=True, verbose_name='Цвет')),
+                ('number', models.IntegerField(blank=True, null=True, verbose_name='Номер линии')),
+                ('icon', models.ImageField(blank=True, null=True, upload_to='metro/', verbose_name='Иконка')),
             ],
             options={
+                'verbose_name': 'Линия метро',
                 'ordering': ['number'],
-                'verbose_name': '\u041b\u0438\u043d\u0438\u044f \u043c\u0435\u0442\u0440\u043e',
-                'verbose_name_plural': '\u041b\u0438\u043d\u0438\u0438 \u043c\u0435\u0442\u0440\u043e',
+                'verbose_name_plural': 'Линии метро',
             },
-            bases=(models.Model,),
         ),
         migrations.AddField(
             model_name='metro',
             name='line',
-            field=models.ForeignKey(verbose_name='\u041b\u0438\u043d\u0438\u044f \u043c\u0435\u0442\u0440\u043e', to='metro.MetroLine'),
-            preserve_default=True,
+            field=models.ForeignKey(on_delete=django.db.models.deletion.CASCADE, to='metro.MetroLine', verbose_name='Линия метро'),
         ),
     ]


### PR DESCRIPTION
For some reason Django 1.9 tried to create an altering icon field:

```
docker-compose run --rm api bash -c './manage.py makemigrations && ./manage.py migrate'
Migrations for 'metro':
  0002_auto_20160824_2348.py:
    - Alter field icon on metroline
```

Basically I just squashed migrations and removed the old one. 
